### PR TITLE
SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,12 @@
 			_ "github.com/bmizerany/pq.go"
 		)
 
-		db, err := sql.Open("postgres", "postgres://blake:@locahost:5432")
+		db, err := sql.Open("postgres", "postgres://blake:@localhost:5432")
 		if err != nil {
 			log.Print(err)
 		}
 
-
-## Unnamed Prepeared Query
+## Unnamed Prepared Query
 
 		rows, err := db.Query("SELECT length($1) AS foo", "hello")
 		if err != nil {
@@ -38,9 +37,9 @@
 ## Notifications
 
 Notifications can't be accessed via the exp/sql package. You will need to use
-pq.OpenRaw to obtain a single connection for listenting.  NOTE: It is recommend
-to only use this connection for reading notifiactions and to use the exp/sql
-API for all other operations. This may change in the future.
+pq.OpenRaw to obtain a single connection for listening.  NOTE: It is
+recommended to only use this connection for reading notifications and to use
+the exp/sql API for all other operations. This may change in the future.
 
 **Example**
 
@@ -67,6 +66,11 @@ API for all other operations. This may change in the future.
 
 **To Know**
 
-When one or more LISTEN's are active, it is the responsiblity of the user to
+When one or more LISTEN's are active, it is the responsibility of the user to
 drain the `db.Notifies` channel; Failing to do so causes reads on the
 connection to block if there are pending notifications on the connection.
+
+## SSL
+
+pq.go always requests SSL from the Postgres server. Encryption is then enabled
+if the server is configured to allow it.

--- a/conn_test.go
+++ b/conn_test.go
@@ -8,8 +8,13 @@ import (
 	"testing"
 )
 
+func LocalAddr() *net.TCPAddr {
+	addr, _ := net.ResolveTCPAddr("tcp", "localhost:5432")
+	return addr
+}
+
 func TestConnPrepareErr(t *testing.T) {
-	nc, err := net.Dial("tcp", "localhost:5432")
+	nc, err := net.DialTCP("tcp", nil, LocalAddr())
 	assert.Equalf(t, nil, err, "%v", err)
 
 	cn, err := New(nc, map[string]string{"user": os.Getenv("USER")}, "")
@@ -19,8 +24,19 @@ func TestConnPrepareErr(t *testing.T) {
 	assert.NotEqual(t, nil, err)
 }
 
+func TestSsl(t *testing.T) {
+	nc, err := net.DialTCP("tcp", nil, LocalAddr())
+	assert.Equalf(t, nil, err, "%v", err)
+
+	cn, err := NewWithSsl(nc, map[string]string{"user": os.Getenv("USER")}, "")
+	assert.Equalf(t, nil, err, "%v", err)
+
+	_, err = cn.Prepare("SELECT 1")
+	assert.Equal(t, nil, err)
+}
+
 func TestConnPrepare(t *testing.T) {
-	nc, err := net.Dial("tcp", "localhost:5432")
+	nc, err := net.DialTCP("tcp", nil, LocalAddr())
 	assert.Equalf(t, nil, err, "%v", err)
 
 	cn, err := New(nc, map[string]string{"user": os.Getenv("USER")}, "")
@@ -51,7 +67,7 @@ func TestConnPrepare(t *testing.T) {
 }
 
 func TestConnNotify(t *testing.T) {
-	nc, err := net.Dial("tcp", "localhost:5432")
+	nc, err := net.DialTCP("tcp", nil, LocalAddr())
 	assert.Equalf(t, nil, err, "%v", err)
 
 	cn, err := New(nc, map[string]string{"user": os.Getenv("USER")}, "")

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -33,6 +33,28 @@ func (vs Values) Del(k string) {
 	delete(vs, k)
 }
 
+func SslRequest(cn io.ReadWriter) (bool, error) {
+	err := binary.Write(cn, binary.BigEndian, int32(8))
+	if err != nil {
+		return false, err
+	}
+
+	b := NewBuffer(nil)
+	b.WriteInt32(int32(80877103))
+	_, err = b.WriteTo(cn)
+	if err != nil {
+		return false, err
+	}
+
+	// Read response
+	resp := make([]byte, 1, 1)
+	_, err = cn.Read(resp)
+	if err != nil {
+		return false, err
+	}
+	return (resp[0] == 'S'), nil
+}
+
 type Conn struct {
 	b   *Buffer
 	scr *scanner


### PR DESCRIPTION
Always perform an SSLRequest at the beginning of the connection to determine if the server is configured for SSL.
- If the server responds with an `S`, then the connection will proceed
  wrapped in a TLS connection.
- If the server responds with an `N`, the connection will proceed
  unencrypted.

In order to test this with SSL, you'll need to have your local postgres configured properly.
